### PR TITLE
Fixing Compiler Warnings in XCode

### DIFF
--- a/src/main/Group.h
+++ b/src/main/Group.h
@@ -2,7 +2,7 @@
 #import "Sequence.h"
 
 @interface Group : Sequence
-@property(nonatomic) id <NSObject> key;
+@property(nonatomic, strong) id <NSObject> key;
 
 - (Group *)initWithKey:(id)aKey enumerable:(id <Enumerable>)anEnumerable;
 


### PR DESCRIPTION
Two warnings were showing up repeatedly on builds. 
1) "No 'assign, 'retain', or 'copy' attribute is specified - 'assign' is assumed"
2) "Default property attribute 'assign' not appropriate for non-GC object"

I'm not 100% sure if strong is the right way to fix this but it definitely removes the warnings
