### PR TITLE
Bumping the version number on the podspec

### DIFF
--- a/OCTotallyLazy.podspec
+++ b/OCTotallyLazy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OCTotallyLazy"
-  s.version      = "1.0.0"
+  s.version      = "1.1.0"
   s.summary      = "Functional extensions to Objective C's collections."
   s.description  = <<-DESC
                     OCTotallyLazy is a framework that adds functional behaviour to 


### PR DESCRIPTION
This commit bumps the version number on the local podspec. A new tag should be introduced after this is accepted to allow for a 1.1.0 version of the project (with all changes added since 1.0.0). Once this is done I can update the podspec on the Cocoapods specs repo.
