### PR TITLE
map, flatMap, and flatten work on one level

### DIFF
--- a/src/main/Callables.h
+++ b/src/main/Callables.h
@@ -5,6 +5,8 @@ typedef NSNumber *(^CALLABLE_TO_NUMBER)(id);
 typedef NSString *(^ACCUMULATOR_TO_STRING)(id, id);
 
 @interface Callables : NSObject
++ (id (^)(id))identity;
+
 + (NSString * (^)(NSString *))toUpperCase;
 
 + (NSString * (^)(NSString *, NSString *))appendString;

--- a/src/main/Callables.m
+++ b/src/main/Callables.m
@@ -1,6 +1,10 @@
 #import "Callables.h"
 
 @implementation Callables
++ (id (^)(id))identity {
+    return [^(id item) { return item; } copy];
+}
+
 + (NSString * (^)(NSString *))toUpperCase {
     return [^(NSString *item) { return item.uppercaseString; } copy];
 }

--- a/src/main/enumerators/FlattenEnumerator.m
+++ b/src/main/enumerators/FlattenEnumerator.m
@@ -20,7 +20,7 @@
     while((item = [currentEnumerator nextObject]) == nil) {
         id nextItem = [enumerator nextObject];
         if ([nextItem respondsToSelector:@selector(toEnumerator)]) {
-            currentEnumerator = [FlattenEnumerator withEnumerator:[nextItem toEnumerator]];
+            currentEnumerator = [nextItem toEnumerator];
             continue;
         }
         return nextItem;

--- a/src/main/enumerators/MapEnumerator.m
+++ b/src/main/enumerators/MapEnumerator.m
@@ -20,7 +20,7 @@
 
 - (id)nextObject {
     id item = [enumerator nextObject];
-    return (item == nil) ? nil : [item conformsToProtocol:@protocol(Mappable)] ? [item map:func] : func(item);
+    return (item == nil) ? nil : func(item);
 }
 
 

--- a/src/test-unit/NSArrayTest.m
+++ b/src/test-unit/NSArrayTest.m
@@ -39,16 +39,18 @@
             array(@"one", @"two", nil),
             array(@"three", @"four", nil),
             nil);
-    assertThat([items flatMap:[Callables toUpperCase]], hasItems(@"ONE", @"TWO", @"THREE", @"FOUR", nil));
+    assertThat([items flatMap:[Callables identity]], hasItems(@"one", @"two", @"three", @"four", nil));
 }
 
--(void)testFlatMapSupportsNDepthSequences {
+-(void)testFlatMapFlattensOnlyOneLevel {
     NSArray *items = array(
             @"one",
             array(@"two", @"three", nil),
             array(array(@"four", nil), nil),
             nil);
-    assertThat([items flatMap:[Callables toUpperCase]], hasItems(@"ONE", @"TWO", @"THREE", @"FOUR", nil));
+    NSArray *flatMapped = [items flatMap:[Callables identity]];
+    assertThat(flatMapped, hasItems(@"one", @"two", @"three", nil));
+    assertThat([flatMapped objectAtIndex:3], hasItems(@"four", nil));
 }
 
 -(void)testFlattenResolvesOptions {


### PR DESCRIPTION
- Map and Flatten Enumerators are no longer recursive.
- Added [Callable identity] to use in testing flatMap.
- Removed testMapLiftsMappables - map shouldn’t lift mappables
- All tests working