### PR TITLE
Suppress Implicit conversion warnings.

### DIFF
--- a/OCTotallyLazy/NSArray+OCTotallyLazy.m
+++ b/OCTotallyLazy/NSArray+OCTotallyLazy.m
@@ -157,7 +157,7 @@
 }
 
 - (NSArray *)takeRight:(int)n {
-    int toTake = (n > [self count]) ? [self count] : (NSUInteger) n;
+    NSUInteger toTake = (n > [self count]) ? [self count] : (NSUInteger) n;
     return [self subarrayWithRange:NSMakeRange([self count] - toTake, (NSUInteger) toTake)];
 }
 
@@ -201,8 +201,8 @@
     Pair *keysAndValues = [self partition:TL_alternate(YES)];
     NSArray *keys = keysAndValues.left;
     NSArray *values = keysAndValues.right;
-    values = [values take:[keys count]];
-    keys = [keys take:[values count]];
+    values = [values take:(int)[keys count]];
+    keys = [keys take:(int)[values count]];
     NSEnumerator *valueEnumerator = [keysAndValues.right objectEnumerator];
     return [keys fold:[NSMutableDictionary dictionary] with:^(NSMutableDictionary *accumulator, id key) {
         [accumulator setObject:[valueEnumerator nextObject] forKey:key];

--- a/OCTotallyLazy/enumerators/MemoisedEnumerator.m
+++ b/OCTotallyLazy/enumerators/MemoisedEnumerator.m
@@ -8,11 +8,11 @@
 }
 
 - (int)previousIndex {
-    return position - 1;
+    return (int)position - 1;
 }
 
 - (int)nextIndex {
-    return position;
+    return (int)position;
 }
 
 - (id)previousObject {


### PR DESCRIPTION
Suppress Implicit conversion warnings by using the correct data type or adding casts.
